### PR TITLE
Fixed "size is not defined" error when reporting options is defined. #6

### DIFF
--- a/tasks/filesize.js
+++ b/tasks/filesize.js
@@ -201,8 +201,8 @@ module.exports = function(grunt) {
     var opts = this.options({});
     if(opts.reporting){
       grunt.log.writeln(">>".yello + " reporting options is now obsolete.");
-      this.files.forEach(function(file) {
-        grunt.file.write(opts.reporting(file.dest), 'YVALUE=' + size + '\n');
+      files.forEach(function(file) {
+        grunt.file.write(opts.reporting(file.dest), 'YVALUE=' + file.size + '\n');
       });
     }
 


### PR DESCRIPTION
undefined reporting options is now obsolete.
Warning: size is not defined Used --force, continuing.
