### PR TITLE
Correct typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ grunt.initConfig({
         {expand: true, cwd: 'build', src: ['*.css', '*.js']}
       ],
       options: {
-        ouput: [
+        output: [
           {
             stdout: true
           },


### PR DESCRIPTION
The typo is a rather frustrating one. I had overlooked that it should say `output` not `ouput`. The result is that none of my settings were having any effect. After stepping through the code with the debugger I realised that my config was wrong and I had copied and pasted it from `README.md`.
